### PR TITLE
fix version detection regex

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.13
-          cache: poetry
       - name: Install dependencies
         run: |
           poetry install --only main,docs

--- a/.github/workflows/testbuild.yml
+++ b/.github/workflows/testbuild.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
-          cache: poetry
+          python-version: 3.13
       - name: Install dependencies
         run: |
           poetry install --only main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,12 @@ repos:
     rev: v1.1.0
     hooks:
       - id: poetry-hook-latest
+        args: ["--only=main"]
   - repo: local
     hooks:
       - id: readme
         name: rendering readme
         entry: poetry run python docs/readme.py
+        stages: [pre-commit]
         language: system
         files: docs/README\.md\.jinja2$

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## install
 
-```shell
+```cmd
 $ pip install poetry-plugin-hook
 ```
 
@@ -24,7 +24,7 @@ or with `poetry`
 
 > Especially on [Windows](https://python-poetry.org/docs/cli/#self), self commands that update or remove packages may be problematic.
 
-```shell
+```cmd
 $ poetry self add poetry-plugin-hook
 ```
 
@@ -34,7 +34,7 @@ Wrapper for `poetry show -o -T` command.
 
 Exit code represents the number of outdated packages.
 
-```shell
+```cmd
 $ poetry hook latest --help
 
   Description:
@@ -74,7 +74,7 @@ Wrapper for `poetry install --sync` command.
 
 With `--exit` option, the command returns the corresponding value as exit code. With it's default `--exit=any` the sum of *installs*, *updates* and *removals* is returned.
 
-```shell
+```cmd
 $ poetry hook sync --help
 
   Description:
@@ -120,6 +120,7 @@ repos:
     rev: v1.1.0
     hooks:
         - id: poetry-hook-latest
+          args: ["--only=main"]
         - id: poetry-hook-sync
           args: [ "--dry-run" ]
 ```
@@ -127,20 +128,20 @@ repos:
 ### usage
 
 1. Make sure pre-commit is installed, see [official documentation](https://pre-commit.com/#installation).
-  ```shell
+  ```cmd
   $ pre-commit --version
 
     pre-commit 3.7.1
   ```
 2. `cd` into your project and register hooks and install them. this may take a while.
-  ```shell
+  ```cmd
   $ pre-commit install --install-hooks -t pre-commit -t pre-push
 
     pre-commit installed at .git\hooks\pre-commit
     pre-commit installed at .git\hooks\pre-push
   ```
 3. Test the pre-push hook.
-  ```shell
+  ```cmd
   $ pre-commit run poetry-hook-latest --all-files --hook-stage pre-push
 
     poetry-hook-latest.......................................................Failed
@@ -150,7 +151,7 @@ repos:
     pytest-cov 5.0.0 6.0.0 Pytest plugin for measuring coverage.
   ```
 4. Test the pre-commit hooks.
-  ```shell
+  ```cmd
   $ pre-commit run poetry-hook-sync --all-files
 
     poetry-hook-sync.........................................................Failed

--- a/docs/README.md.jinja2
+++ b/docs/README.md.jinja2
@@ -16,7 +16,7 @@
 
 ## install
 
-```shell
+```cmd
 $ pip install poetry-plugin-hook
 ```
 
@@ -24,7 +24,7 @@ or with `poetry`
 
 > Especially on [Windows](https://python-poetry.org/docs/cli/#self), self commands that update or remove packages may be problematic.
 
-```shell
+```cmd
 $ poetry self add poetry-plugin-hook
 ```
 
@@ -34,7 +34,7 @@ Wrapper for `poetry show -o -T` command.
 
 Exit code represents the number of outdated packages.
 
-```shell
+```cmd
 {{ "poetry hook latest --help" | shell }}
 ```
 
@@ -44,7 +44,7 @@ Wrapper for `poetry install --sync` command.
 
 With `--exit` option, the command returns the corresponding value as exit code. With it's default `--exit=any` the sum of *installs*, *updates* and *removals* is returned.
 
-```shell
+```cmd
 {{ "poetry hook sync --help" | shell }}
 ```
 
@@ -58,6 +58,7 @@ repos:
     rev: v1.1.0
     hooks:
         - id: poetry-hook-latest
+          args: ["--only=main"]
         - id: poetry-hook-sync
           args: [ "--dry-run" ]
 ```
@@ -65,20 +66,20 @@ repos:
 ### usage
 
 1. Make sure pre-commit is installed, see [official documentation](https://pre-commit.com/#installation).
-  ```shell
+  ```cmd
   $ pre-commit --version
 
     pre-commit 3.7.1
   ```
 2. `cd` into your project and register hooks and install them. this may take a while.
-  ```shell
+  ```cmd
   $ pre-commit install --install-hooks -t pre-commit -t pre-push
 
     pre-commit installed at .git\hooks\pre-commit
     pre-commit installed at .git\hooks\pre-push
   ```
 3. Test the pre-push hook.
-  ```shell
+  ```cmd
   $ pre-commit run poetry-hook-latest --all-files --hook-stage pre-push
 
     poetry-hook-latest.......................................................Failed
@@ -88,7 +89,7 @@ repos:
     pytest-cov 5.0.0 6.0.0 Pytest plugin for measuring coverage.
   ```
 4. Test the pre-commit hooks.
-  ```shell
+  ```cmd
   $ pre-commit run poetry-hook-sync --all-files
 
     poetry-hook-sync.........................................................Failed

--- a/poetry_plugin_hook/latest.py
+++ b/poetry_plugin_hook/latest.py
@@ -10,10 +10,20 @@ class LatestCommand(ShowCommand):
     description = "Check if all top-level dependencies are up-to-date."
     help = "poetry hook latest [options]"
 
+    _version = (
+        r"([1-9][0-9]*!)?"
+        r"(0|[1-9][0-9]*)"
+        r"(\.(0|[1-9][0-9]*))*"
+        r"((a|b|rc)(0|[1-9][0-9]*))?"
+        r"(\.post(0|[1-9][0-9]*))?"
+        r"(\.dev(0|[1-9][0-9]*))?"
+    )
+    """PEP 440 version regex."""
+
     _dependencies = re.compile(
         r"^(?P<package>.*?)\s+"
-        r"(?P<current>\d\.\d\.\d\S*)\s+"
-        r"(?P<latest>\d\.\d\.\d\S*)\s+"
+        rf"(?P<current>{_version})\s+"
+        rf"(?P<latest>{_version})\s+"
         r"(?P<description>.*?)$",
         re.MULTILINE,
     )

--- a/tests/mock_hooks.json
+++ b/tests/mock_hooks.json
@@ -372,5 +372,21 @@
             "",
             ""
         ]
+    },
+    {
+        "args": [
+            "hook",
+            "latest"
+        ],
+        "returncode": 2,
+        "stdout": [
+            "py7zr      0.20.8   0.22.0    Pure python 7-zip library",
+            "pytest-cov 4.1.0    6.0.0     Pytest plugin for measuring coverage.",
+            ""
+        ],
+        "stderr": [
+            "",
+            ""
+        ]
     }
 ]


### PR DESCRIPTION
Revise the README and documentation to use command syntax suitable for Windows. Improve the hook's latest version detection by implementing a regex based on PEP 440.